### PR TITLE
MarkovChainTest: Add match() and scan() tests for phrase len > model

### DIFF
--- a/nlcmd/src/main/java/com/ktm_technologies/nlcmd/MarkovChain.java
+++ b/nlcmd/src/main/java/com/ktm_technologies/nlcmd/MarkovChain.java
@@ -447,13 +447,11 @@ interface Stream {
      * Invoked when starting to iterate a graph inside the model.
      * @param labelFragments Node label
      */
-    @SuppressWarnings("RedundantThrows")
     void startGraph(String[] labelFragments) throws Exception;
 
     /**
      * Invoked when iteration of the current graph is finished.
      */
-    @SuppressWarnings("RedundantThrows")
     void endGraph() throws Exception;
 
     /**
@@ -461,7 +459,6 @@ interface Stream {
      * @param probability Probability for the edge
      * @param labelFragments Target node label
      */
-    @SuppressWarnings("RedundantThrows")
     void addEdge(double probability,
                  String[] labelFragments)
         throws Exception;
@@ -499,7 +496,6 @@ class MarkovChainMixin {
      * @param id Unique query ID
      * @param node Node that is queried
      * @param label Edge label to query for
-     * @return Next node or NULL
      */
     void updateQuery(int id, Node node, Label label) {
 
@@ -591,6 +587,7 @@ public class MarkovChain {
      * Set custom node factory.
      * @param factory Node factory instance or NULL to reset to default
      */
+    @SuppressWarnings("WeakerAccess")
     public void setNodeFactory(MarkovChainMixin factory) {
 
         if (factory == null) {
@@ -680,6 +677,7 @@ public class MarkovChain {
      * @return Average probability: sum of probabilities / number of edges.
      *         Negative value if phrase shorter than two entries such that matching is not possible.
      */
+    @SuppressWarnings("WeakerAccess")
     public double match(List<String> phrase) {
 
         Result details;
@@ -779,8 +777,11 @@ public class MarkovChain {
      * sub-phrases are made.
      *
      * @param phrase Match phrase
+     * @param matches Map of phrase : probability, may be null
+     * @param placeholders Map of placeholder : variable, may be null
      * @return Average probability: sum of probabilities / number of edges for the best matching sub-phrase
      */
+    @SuppressWarnings("WeakerAccess")
     public double scan(List<String>                     phrase,
                        HashMap<List<String>, Double>    matches,
                        HashMap<String, List<String>>    placeholders) {

--- a/nlcmd/src/main/java/com/ktm_technologies/nlcmd/Result.java
+++ b/nlcmd/src/main/java/com/ktm_technologies/nlcmd/Result.java
@@ -195,7 +195,9 @@ class Result {
                         HashMap<String, List<String>>   placeholders) {
 
         for (Phrase phrase : _entries) {
-            matches.put(phrase.getPhrase(), phrase.getAvgProbability());
+            if (matches != null) {
+                matches.put(phrase.getPhrase(), phrase.getAvgProbability());
+            }
             Placeholder placeholder = phrase.getPlaceholder();
             if (placeholders != null && placeholder != null) {
                 placeholders.put(placeholder.getToken(), placeholder.getPhrase());

--- a/nlcmd/src/test/java/com/ktm_technologies/nlcmd/MarkovChainTest.java
+++ b/nlcmd/src/test/java/com/ktm_technologies/nlcmd/MarkovChainTest.java
@@ -92,6 +92,26 @@ public class MarkovChainTest {
     }
 
     @Test
+    public void markov_matchLongW1() {
+        MarkovChain mc = new MarkovChain(1);
+        List<String> model = Arrays.asList("a b c d".split(" "));
+        mc.train(model);
+        List<String> phrase = Arrays.asList("a b c d e".split(" "));
+        double result = mc.match(phrase);
+        assertEquals(0.0, result, 0.0001);
+    }
+
+    @Test
+    public void markov_scanLongW1() {
+        MarkovChain mc = new MarkovChain(1);
+        List<String> model = Arrays.asList("a b c d".split(" "));
+        mc.train(model);
+        List<String> phrase = Arrays.asList("a b c d e".split(" "));
+        double result = mc.scan(phrase, null, null);
+        assertEquals(1.0, result, 0.0001);
+    }
+
+    @Test
     public void markov_scanSingleFull() {
         MarkovChain mc = createFooBarBazChain();
         List<String> phrase = new LinkedList<>(Arrays.asList("foo", "bar", "baz"));
@@ -272,7 +292,7 @@ public class MarkovChainTest {
         assertTrue(ret);
     }
 
-    public static MarkovChain createFooBarBazChain() {
+    static MarkovChain createFooBarBazChain() {
         MarkovChain mc = new MarkovChain(MarkovChainTest._ORDER);
         List<String> phrase = new LinkedList<>(Arrays.asList("foo", "bar", "baz"));
         mc.train(phrase);
@@ -293,21 +313,21 @@ public class MarkovChainTest {
         return mc;
     }
 
-    public static MarkovChain createFoxChainW1() {
+    static MarkovChain createFoxChainW1() {
         MarkovChain mc = new MarkovChain(1);
         List<String> phrase = new LinkedList<>(Arrays.asList("the quick brown fox jumps over the lazy dog".split( " ")));
         mc.train(phrase);
         return mc;
     }
 
-    public static MarkovChain createFoxChainW2() {
+    static MarkovChain createFoxChainW2() {
         MarkovChain mc = new MarkovChain(2);
         List<String> phrase = new LinkedList<>(Arrays.asList("the quick brown fox jumps over the lazy dog".split( " ")));
         mc.train(phrase);
         return mc;
     }
 
-    public static MarkovChain createFishChainW1() {
+    static MarkovChain createFishChainW1() {
         MarkovChain mc = new MarkovChain(1);
         List<String> phrase = new LinkedList<>(Arrays.asList("one fish two fish red fish blue fish".split( " ")));
         mc.train(phrase);


### PR DESCRIPTION
Behaviour for match() is returning 0, only full matches are considered.
Behaviour for scan() is returning average for matched sub-phrase.

Fixes #24